### PR TITLE
Removes .amp extension from rails_amp_application

### DIFF
--- a/lib/rails_amp/overrider.rb
+++ b/lib/rails_amp/overrider.rb
@@ -29,7 +29,7 @@ module RailsAmp
                     format.send(RailsAmp.default_format.to_sym) do
                       # search amp format(default is .amp) .html templates
                       lookup_context.formats = [RailsAmp.default_format] + RailsAmp.lookup_formats
-                      render layout: 'rails_amp_application.amp'
+                      render layout: 'rails_amp_application'
                     end
                   end
                 end


### PR DESCRIPTION
To avoid, that rendering the `rails_amp_application`-template can't find `.amp`-mime type.